### PR TITLE
feat: Add freezed suport to model brick 

### DIFF
--- a/bricks/model/README.md
+++ b/bricks/model/README.md
@@ -7,18 +7,19 @@ This brick supports custom types and custom lists!
 ## How to use 🚀
 
 ```
-mason make model --model_name user --use_copywith true --use_equatable true --use_json true
+mason make model --model_name user --use_copywith true --use_equatable true --use_json true --model_generator freezed
 ```
 
 ## Variables ✨
 
-| Variable         | Description                      | Default | Type      |
-| ---------------- | -------------------------------- | ------- | --------- |
-| `model_name`     | The name of the model            | model   | `string`  |
-| `use_copywith`   | Create copyWith method           | true    | `boolean` |
-| `use_equatable`  | Creates the equatable overide    | true    | `boolean` |
-| `use_json`       | Creates the from/to json methods | true    | `boolean` |
-| `add_properties` | Add properties                   | true    | `boolean` |
+| Variable          | Description                      | Default | Type      |
+| ----------------  | -------------------------------- | ------- | --------- |
+| `model_name`      | The name of the model            | model   | `string`  |
+| `use_copywith`    | Create copyWith method           | true    | `boolean` |
+| `use_equatable`   | Creates the equatable overide    | true    | `boolean` |
+| `use_json`        | Creates the from/to json methods | true    | `boolean` |
+| `add_properties`  | Add properties                   | true    | `boolean` |
+| `model_generator` | The generator used in the model  | none    | `enum`    |
 
 ## Outputs 📦
 

--- a/bricks/model/README.md
+++ b/bricks/model/README.md
@@ -7,19 +7,19 @@ This brick supports custom types and custom lists!
 ## How to use 🚀
 
 ```
-mason make model --model_name user --use_copywith true --use_equatable true --use_json true --model_generator freezed
+mason make model --model_name user --use_copywith true --use_equatable true --use_json true --model_generator_mode freezed
 ```
 
 ## Variables ✨
 
-| Variable          | Description                      | Default | Type      |
-| ----------------  | -------------------------------- | ------- | --------- |
-| `model_name`      | The name of the model            | model   | `string`  |
-| `use_copywith`    | Create copyWith method           | true    | `boolean` |
-| `use_equatable`   | Creates the equatable overide    | true    | `boolean` |
-| `use_json`        | Creates the from/to json methods | true    | `boolean` |
-| `add_properties`  | Add properties                   | true    | `boolean` |
-| `model_generator` | The generator used in the model  | none    | `enum`    |
+| Variable               | Description                      | Default | Type      |
+| ----------------       | -------------------------------- | ------- | --------- |
+| `model_name`           | The name of the model            | model   | `string`  |
+| `use_copywith`         | Create copyWith method           | true    | `boolean` |
+| `use_equatable`        | Creates the equatable overide    | true    | `boolean` |
+| `use_json`             | Creates the from/to json methods | true    | `boolean` |
+| `add_properties`       | Add properties                   | true    | `boolean` |
+| `model_generator_mode` | The generator used in the model  | none    | `enum`    |
 
 ## Outputs 📦
 

--- a/bricks/model/__brick__/{{#use_json}}{{model_name.snakeCase()}}.g.dart{{/use_json}}
+++ b/bricks/model/__brick__/{{#use_json}}{{model_name.snakeCase()}}.g.dart{{/use_json}}
@@ -1,9 +1,9 @@
 part of '{{model_name.snakeCase()}}.dart';
-
+{{#isNone}}
 {{model_name.pascalCase()}} _${{model_name.pascalCase()}}FromJson(Map<String, dynamic> json) => {{model_name.pascalCase()}}({{#properties}}
       {{name}}: {{#isCustomList}}(json['{{name}}'] as List<dynamic>).map((dynamic e) => {{customListType}}.fromJson(e as Map<String, dynamic>)).toList(){{/isCustomList}}{{^isCustomList}}{{#isCustomDataType}}{{type}}.fromJson(json['{{name}}'] as Map<String, dynamic>){{/isCustomDataType}}{{^isCustomDataType}}json['{{name}}'] as {{#hasSpecial}}{{{type}}}{{/hasSpecial}}{{^hasSpecial}}{{type}}{{/hasSpecial}}{{/isCustomDataType}}{{/isCustomList}},{{/properties}}
     );
 
 Map<String, dynamic> _${{model_name.pascalCase()}}ToJson({{model_name.pascalCase()}} instance) => <String, dynamic>{ {{#properties}}
       '{{name}}': instance.{{name}},{{/properties}}
-    };
+    };{{/isNone}}

--- a/bricks/model/__brick__/{{model_name.snakeCase()}}.dart
+++ b/bricks/model/__brick__/{{model_name.snakeCase()}}.dart
@@ -1,10 +1,34 @@
-{{#use_equatable}}import 'package:equatable/equatable.dart';{{/use_equatable}}{{#use_json}}
+{{#use_equatable}}import 'package:equatable/equatable.dart';{{/use_equatable}}{{#isFreezed}}
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part '{{model_name.snakeCase()}}.freezed.dart';{{/isFreezed}}{{#use_json}}
 
 part '{{model_name.snakeCase()}}.g.dart';{{/use_json}}
 
 /// {@template {{{model_name.snakeCase()}}}}
 /// {{model_name.pascalCase()}} description
 /// {@endtemplate}
+{{#isFreezed}}
+@freezed
+class {{model_name.pascalCase()}}{{#use_equatable}} extends Equatable{{/use_equatable}} with _${{model_name.pascalCase()}} {
+  /// {@macro {{{model_name.snakeCase()}}}}
+  const factory {{model_name.pascalCase()}}({{#hasProperties}}{ {{#properties}}
+    required {{#hasSpecial}}{{{type}}}{{/hasSpecial}}{{^hasSpecial}}{{type}}{{/hasSpecial}} {{name}},{{/properties}}
+  }{{/hasProperties}}) = _{{model_name.pascalCase()}};
+
+  /// Private constructor to enable getters
+  const {{model_name.pascalCase()}}._();{{#use_json}}
+
+  /// Creates a {{model_name.pascalCase()}} from Json map
+  factory {{model_name.pascalCase()}}.fromJson(Map<String, dynamic> data) => _${{model_name.pascalCase()}}FromJson(data);{{/use_json}}{{#use_equatable}}
+
+  @override
+  List<Object?> get props => [{{#properties}}
+    {{name}},{{/properties}}
+  ];{{/use_equatable}}
+}
+{{/isFreezed}}{{#isNone}}
 class {{model_name.pascalCase()}}{{#use_equatable}} extends Equatable{{/use_equatable}} {
   /// {@macro {{{model_name.snakeCase()}}}}
   const {{model_name.pascalCase()}}({{#hasProperties}}{ {{#properties}}
@@ -34,3 +58,4 @@ class {{model_name.pascalCase()}}{{#use_equatable}} extends Equatable{{/use_equa
   /// Creates a Json map from a {{model_name.pascalCase()}}
   Map<String, dynamic> toJson() => _${{model_name.pascalCase()}}ToJson(this);{{/use_json}}
 }
+{{/isNone}}

--- a/bricks/model/brick.yaml
+++ b/bricks/model/brick.yaml
@@ -24,11 +24,11 @@ vars:
     type: boolean
     description: Has Json methods
     prompt: Does this model use json?
-  model_generator:
+  model_generator_mode:
     type: enum
     default: none
-    description: The generator used in the model
-    prompt: What is the generator that should be used in model?
+    description: The generator mode used in the model
+    prompt: What is the generator mode that should be used in model?
     values:
       - freezed
       - none

--- a/bricks/model/brick.yaml
+++ b/bricks/model/brick.yaml
@@ -24,3 +24,11 @@ vars:
     type: boolean
     description: Has Json methods
     prompt: Does this model use json?
+  model_generator:
+    type: enum
+    default: none
+    description: The generator used in the model
+    prompt: What is the generator that should be used in model?
+    values:
+      - freezed
+      - none

--- a/bricks/model/hooks/post_gen.dart
+++ b/bricks/model/hooks/post_gen.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:mason/mason.dart';
+
+void run(HookContext context) async {
+  final useEquatable = context.vars["use_equatable"];
+  final usesJson = context.vars["use_json"];
+  final modelGenerator =
+      context.vars["model_generator_mode"].toString().toLowerCase();
+  final usesFreezed = modelGenerator == 'freezed';
+
+  final directory = Directory.current.path;
+  final folders = directory.toString().split('/').toList();
+  final index = folders.indexWhere((folder) => folder == 'lib');
+  final root = folders.sublist(0, index).join('/').toString();
+
+  if (useEquatable) {
+    final addEquatableProcess = await Process.start(
+      'flutter',
+      ['pub', 'add', 'equatable'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(addEquatableProcess.stdout);
+    await stderr.addStream(addEquatableProcess.stderr);
+  }
+
+  if (usesJson) {
+    final addJsonProcess = await Process.start(
+      'flutter',
+      ['pub', 'add', 'json_annotation'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(addJsonProcess.stdout);
+    await stderr.addStream(addJsonProcess.stderr);
+    final addJsonDevProcess = await Process.start(
+      'flutter',
+      ['pub', 'add', '--dev', 'json_serializable'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(addJsonDevProcess.stdout);
+    await stderr.addStream(addJsonDevProcess.stderr);
+  }
+
+  if (usesFreezed) {
+    final addFreezedProcess = await Process.start(
+      'flutter',
+      ['pub', 'add', 'freezed_annotation'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(addFreezedProcess.stdout);
+    await stderr.addStream(addFreezedProcess.stderr);
+    final addBuildRunnerProcess = await Process.start(
+      'flutter',
+      ['pub', 'add', '--dev', 'build_runner'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(addBuildRunnerProcess.stdout);
+    await stderr.addStream(addBuildRunnerProcess.stderr);
+    final addFreezedDevProcess = await Process.start(
+      'flutter',
+      ['pub', 'add', '--dev', 'freezed'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(addFreezedDevProcess.stdout);
+    await stderr.addStream(addFreezedDevProcess.stderr);
+  }
+
+  if (useEquatable || usesJson || usesFreezed) {
+    final pubGetProcess = await Process.start(
+      'flutter',
+      ['pub', 'get'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(pubGetProcess.stdout);
+    await stderr.addStream(pubGetProcess.stderr);
+  }
+
+  if (usesFreezed) {
+    final buildRunnerProcess = await Process.start(
+      'flutter',
+      ['pub', 'run', 'build_runner', 'build', '--delete-conflicting-outputs'],
+      runInShell: true,
+      workingDirectory: root,
+    );
+    await stdout.addStream(buildRunnerProcess.stdout);
+    await stderr.addStream(buildRunnerProcess.stderr);
+  }
+}

--- a/bricks/model/hooks/pre_gen.dart
+++ b/bricks/model/hooks/pre_gen.dart
@@ -16,6 +16,10 @@ final dataTypes = [
 void run(HookContext context) {
   final logger = context.logger;
 
+  final modelGenerator = context.vars["model_generator"].toString().toLowerCase();
+  final isFreezed = modelGenerator == 'freezed';
+  final isNone = !isFreezed;
+
   if (!logger.confirm(
     '? Do you want to add properties to your model?',
     defaultValue: true,
@@ -23,6 +27,8 @@ void run(HookContext context) {
     context.vars = {
       ...context.vars,
       'hasProperties': false,
+      'isFreezed': isFreezed,
+      'isNone': isNone,
     };
     return;
   }
@@ -69,6 +75,8 @@ void run(HookContext context) {
     ...context.vars,
     'properties': properties,
     'hasProperties': properties.isNotEmpty,
+    'isFreezed': isFreezed,
+    'isNone': isNone,
   };
 }
 

--- a/bricks/model/hooks/pre_gen.dart
+++ b/bricks/model/hooks/pre_gen.dart
@@ -16,7 +16,7 @@ final dataTypes = [
 void run(HookContext context) {
   final logger = context.logger;
 
-  final modelGenerator = context.vars["model_generator"].toString().toLowerCase();
+  final modelGenerator = context.vars["model_generator_mode"].toString().toLowerCase();
   final isFreezed = modelGenerator == 'freezed';
   final isNone = !isFreezed;
 


### PR DESCRIPTION
## Brick

<!--- Put an `x` in all the boxes that apply: -->

- [x] model
- [ ] feature_brick
- [ ] app_ui
- [ ] service
- [ ] service_package

## Status

**READY**

## Breaking Changes

NO

## Description

This pull request propose code changes required to address #13 
Added way to choose model generator mode. Currently supported options are either freezed or none.
It also adds `post_gen.dart` script that tries to add required dependencies using pub add and if freezed were used as generator mode runs `build_runner`.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
