### PR TITLE
updated to use super parameters (new in dart 2.17)

### DIFF
--- a/bricks/feature_brick/__brick__/{{feature_name.snakeCase()}}/view/{{feature_name.snakeCase()}}_page.dart
+++ b/bricks/feature_brick/__brick__/{{feature_name.snakeCase()}}/view/{{feature_name.snakeCase()}}_page.dart
@@ -9,7 +9,7 @@ import 'package:{{{fullPath}}}/widgets/{{feature_name.snakeCase()}}_body.dart';
 /// {@endtemplate}
 class {{feature_name.pascalCase()}}Page extends StatelessWidget {
   /// {@macro {{feature_name.snakeCase()}}_page}
-  const {{feature_name.pascalCase()}}Page({Key? key}) : super(key: key);
+  const {{feature_name.pascalCase()}}Page({super.key});
 
   /// The static route for {{feature_name.pascalCase()}}Page
   static Route<dynamic> route() {
@@ -63,7 +63,7 @@ class {{feature_name.pascalCase()}}Page extends StatelessWidget {
 /// {@endtemplate}
 class {{feature_name.pascalCase()}}View extends StatelessWidget {
   /// {@macro {{feature_name.snakeCase()}}_view}
-  const {{feature_name.pascalCase()}}View({Key? key}) : super(key: key);
+  const {{feature_name.pascalCase()}}View({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/bricks/feature_brick/__brick__/{{feature_name.snakeCase()}}/widgets/{{feature_name.snakeCase()}}_body.dart
+++ b/bricks/feature_brick/__brick__/{{feature_name.snakeCase()}}/widgets/{{feature_name.snakeCase()}}_body.dart
@@ -11,7 +11,7 @@ import 'package:{{{fullPath}}}/provider/provider.dart';{{/isRiverpod}}
 /// {@endtemplate}
 class {{feature_name.pascalCase()}}Body {{#isBloc}}extends StatelessWidget{{/isBloc}}{{#isCubit}}extends StatelessWidget{{/isCubit}}{{#isProvider}}extends StatelessWidget{{/isProvider}}{{#isNone}}extends StatelessWidget{{/isNone}}{{#isRiverpod}}extends ConsumerWidget{{/isRiverpod}} {
   /// {@macro {{feature_name.snakeCase()}}_body}
-  const {{feature_name.pascalCase()}}Body({Key? key}) : super(key: key);
+  const {{feature_name.pascalCase()}}Body({super.key});
 {{#isBloc}}
   @override
   Widget build(BuildContext context) {

--- a/examples/feature_brick/login/view/login_page.dart
+++ b/examples/feature_brick/login/view/login_page.dart
@@ -7,7 +7,7 @@ import '../widgets/login_body.dart';
 /// {@endtemplate}
 class LoginPage extends StatelessWidget {
   /// {@macro login_page}
-  const LoginPage({Key? key}) : super(key: key);
+  const LoginPage({super.key});
 
   /// The static route for LoginPage
   static Route<dynamic> route() {
@@ -30,7 +30,7 @@ class LoginPage extends StatelessWidget {
 /// {@endtemplate}
 class LoginView extends StatelessWidget {
   /// {@macro login_view}
-  const LoginView({Key? key}) : super(key: key);
+  const LoginView({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/feature_brick/login/widgets/login_body.dart
+++ b/examples/feature_brick/login/widgets/login_body.dart
@@ -8,7 +8,7 @@ import '../bloc/bloc.dart';
 /// {@endtemplate}
 class LoginBody extends StatelessWidget {
   /// {@macro login_body}
-  const LoginBody({Key? key}) : super(key: key);
+  const LoginBody({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
use these parameters instead of the old way.

tutorial about super parameters.
https://codewithandrea.com/tips/dart-2.17-super-initializers/



## Brick


- [ ] model
- [x] feature_brick
- [ ] app_ui
- [ ] service
- [ ] service_package

## Status

**READY**

## Breaking Changes

NO

## Description

I have edited the way of defining super parameters so there won't be a linting error in the IDE.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
