### PR TITLE
🎉: Model 0.5.0 support seeding/configs and relations

### DIFF
--- a/bricks/model/CHANGELOG.md
+++ b/bricks/model/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.5.0
+
+- feat: Allow for seeding/configs for a whole model including the properties
+
+- feat: Relate models to generate their imports (Currently config only)
+
+- chore: Update documentation with information about configs and how it differs from regular command line generation
+
 # 0.4.1
 
 - fix: Update brick.yaml with `defaults` instead of `default`

--- a/bricks/model/README.md
+++ b/bricks/model/README.md
@@ -2,24 +2,65 @@
 
 A brick to create your model with properties and all the supporting methods, copyWith, to/from json, equatable and more!
 
-This brick supports custom types and custom lists!
+This brick now supports configs! See below for more info.
+
+## Table of Contents
+
+- [How to use](#how-to-use-🚀)
+  - [Model from Command Line](#command-line)
+  - [Model from Config](#config)
+- [Outputs](#outputs)
 
 ## How to use 🚀
 
-```
-mason make model --model_name user --additionals "[copyWith, json, equatable]" --style basic
-```
+### Command Line
+
+`mason make model --model_name user --additionals "[copyWith, json, equatable]" --style basic`
 
 Then add your properties! (Optional)
 
-## Variables ✨
+## Variables for the Command Line ✨
 
-| Variable         | Description                                                | Default                                   | Type      |
-| ---------------- | ---------------------------------------------------------- | ----------------------------------------- | --------- |
-| `model_name`     | The name of the model                                      | model                                     | `string`  |
-| `additionals`    | The additionals methods/extensions you can have on a model | [copyWith, json, equatable]               | `array`   |
-| `style`          | The style of model                                         | basic (basic, json_serializable, freezed) | `enum`    |
-| `add_properties` | Add properties                                             | true                                      | `boolean` |
+| Variable      | Description                                                | Default                                   | Type     |
+| ------------- | ---------------------------------------------------------- | ----------------------------------------- | -------- |
+| `model_name`  | The name of the model                                      | model                                     | `string` |
+| `additionals` | The additionals methods/extensions you can have on a model | [copyWith, json, equatable]               | `array`  |
+| `style`       | The style of model                                         | basic (basic, json_serializable, freezed) | `enum`   |
+
+### Config
+
+`mason make model -c model_config.json`
+
+[Example Config](https://github.com/LukeMoody01/mason_bricks/tree/master/bricks/model/model_config_template.json):
+
+```json
+{
+  "model_name": "super user",
+  "additionals": ["copyWith", "json", "equatable"],
+  "style": "json_serializable", // Could be basic, json_serializable, or freezed
+  "relations": [{ "name": "user" }], // Use this when your model depends on other models
+  "properties": [
+    { "name": "firstName", "type": "String" },
+    { "name": "lastName", "type": "String" },
+    { "name": "age", "type": "int" },
+    { "name": "isHappy", "type": "bool" },
+    { "name": "favouriteNumber", "type": "int" },
+    { "name": "nicknames", "type": "List<String>" },
+    { "name": "countriesVisited", "type": "List<String>" },
+    { "name": "friends", "type": "List<User>" } // We will need `relations` because of this model `List<User>`
+  ]
+}
+```
+
+## Variables for a Config ✨
+
+| Variable      | Description                                                                    | Type     |
+| ------------- | ------------------------------------------------------------------------------ | -------- |
+| `model_name`  | The name of the model                                                          | `string` |
+| `additionals` | The additionals methods/extensions you can have on a model                     | `array`  |
+| `style`       | The style of model                                                             | `enum`   |
+| `relations`   | The models that the current model will depend on and will need the imports for | `array`  |
+| `properties`  | The properties for the model                                                   | `array`  |
 
 ## Outputs 📦
 

--- a/bricks/model/__brick__/{{~ basic_from_json }}
+++ b/bricks/model/__brick__/{{~ basic_from_json }}
@@ -1,4 +1,4 @@
 /// Creates a {{model_name.pascalCase()}} from Json map
-{{model_name.pascalCase()}} fromJson(Map<String, dynamic> json) => {{model_name.pascalCase()}}({{#properties}}
+factory {{model_name.pascalCase()}}.fromJson(Map<String, dynamic> json) => {{model_name.pascalCase()}}({{#properties}}
       {{name}}: {{#isCustomList}}(json['{{name}}'] as List<dynamic>).map((dynamic e) => {{customListType}}.fromJson(e as Map<String, dynamic>)).toList(){{/isCustomList}}{{^isCustomList}}{{#isCustomDataType}}{{type}}.fromJson(json['{{name}}'] as Map<String, dynamic>){{/isCustomDataType}}{{^isCustomDataType}}json['{{name}}'] as {{#hasSpecial}}{{{type}}}{{/hasSpecial}}{{^hasSpecial}}{{type}}{{/hasSpecial}}{{/isCustomDataType}}{{/isCustomList}},{{/properties}}
     );

--- a/bricks/model/__brick__/{{~ basic_model }}
+++ b/bricks/model/__brick__/{{~ basic_model }}
@@ -1,5 +1,5 @@
 {{#use_equatable}}import 'package:equatable/equatable.dart';{{/use_equatable}}
-
+{{> relations }}
 /// {@template {{{model_name.snakeCase()}}}}
 /// {{model_name.pascalCase()}} description
 /// {@endtemplate}

--- a/bricks/model/__brick__/{{~ freezed_model }}
+++ b/bricks/model/__brick__/{{~ freezed_model }}
@@ -1,5 +1,6 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
-
+{{> relations }}
+ 
 part '{{model_name.snakeCase()}}.freezed.dart';
 {{#use_json}}part '{{model_name.snakeCase()}}.g.dart';{{/use_json}}
 

--- a/bricks/model/__brick__/{{~ relations }}
+++ b/bricks/model/__brick__/{{~ relations }}
@@ -1,0 +1,2 @@
+{{#hasRelations}}{{#relations}}import 'package:{{{fullPath}}}{{name.snakeCase()}}.dart';
+{{/relations}}{{/hasRelations}}

--- a/bricks/model/__brick__/{{~ serializable_model }}
+++ b/bricks/model/__brick__/{{~ serializable_model }}
@@ -1,5 +1,6 @@
 {{#use_equatable}}import 'package:equatable/equatable.dart';{{/use_equatable}}
 import 'package:json_annotation/json_annotation.dart';
+{{> relations }}
 
 part '{{model_name.snakeCase()}}.g.dart';
 

--- a/bricks/model/brick.yaml
+++ b/bricks/model/brick.yaml
@@ -1,6 +1,6 @@
 name: model
 description: A brick to create your model with properties and all the supporting methods, copyWith, to/from json, equatable and more!
-version: 0.4.1
+version: 0.5.0
 repository: https://github.com/LukeMoody01/mason_bricks/tree/master/bricks/model
 
 vars:

--- a/bricks/model/hooks/pre_gen.dart
+++ b/bricks/model/hooks/pre_gen.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:mason/mason.dart';
+import 'package:yaml/yaml.dart';
 
 final dataTypes = [
   'String',
@@ -15,12 +17,15 @@ final dataTypes = [
   'DateTime',
 ];
 
-void run(HookContext context) {
+Future<void> run(HookContext context) async {
   final logger = context.logger;
   final additionals = context.vars['additionals'];
   final model_style = context.vars['style'] as String;
-  final vars = {
+  final hasRelations = (context.vars["relations"] != null &&
+      (context.vars['relations'] as List).isNotEmpty);
+  context.vars = {
     ...context.vars,
+    'hasRelations': hasRelations,
     'use_copywith': additionals.contains('copyWith'),
     'use_json': additionals.contains('json'),
     'use_equatable': additionals.contains('equatable'),
@@ -29,39 +34,71 @@ void run(HookContext context) {
     'use_freezed': model_style == 'freezed',
   };
 
+  final hasSeededProperties = (context.vars['properties'] != null &&
+      (context.vars['properties'] as List).isNotEmpty);
+
+  // For freezed check:
   // As the post_gen has the option to run build_runner, we make this check
-  // beforehand to make sure we are in the lib directory
-  if (model_style == 'freezed') {
-    final directory = Directory.current.path;
-    List<String> folders;
-
-    if (Platform.isWindows) {
-      folders = directory.split(r'\').toList();
-    } else {
-      folders = directory.split('/').toList();
-    }
-    final libIndex = folders.indexWhere((folder) => folder == 'lib');
-
-    if (libIndex == -1) {
-      throw Exception(
-          'If you are using freezed, the output directory should be inside the lib folder.');
-    }
+  // beforehand to make sure we are in the lib directory.
+  //
+  // For relations check:
+  // As relations requires the lib directory, we make this check
+  // beforehand to make sure we are in the lib directory.
+  if (model_style == 'freezed' || hasRelations) {
+    final progress = logger.progress('Validating output directory');
+    await _validateDirectory(context);
+    progress.complete('Valid output directory!');
   }
 
-  if (!logger.confirm(
+  final properties = <Map<String, dynamic>>[];
+
+  if (hasSeededProperties) {
+    final seededProperties = context.vars['properties'] as List;
+    _verifySeededProperties(seededProperties, logger);
+    for (final property in seededProperties) {
+      _addProperty(
+        properties,
+        Property(
+          name: property['name'],
+          type: property['type'],
+        ),
+      );
+    }
+  } else if (logger.confirm(
     '? Do you want to add properties to your model?',
     defaultValue: true,
   )) {
-    context.vars = {
-      ...vars,
-      'hasProperties': false,
-    };
-    return;
+    _addProperties(logger, properties);
   }
 
-  logger.alert(lightYellow.wrap('enter "e" to exit adding properties'));
-  logger.alert('Format: dataType propertyName e.g, String myProperty:');
-  final properties = <Map<String, dynamic>>[];
+  context.vars = {
+    ...context.vars,
+    'properties': properties,
+    'hasProperties': properties.isNotEmpty,
+  };
+}
+
+/// Verifies if the seeded properties / config is acceptable
+void _verifySeededProperties(List seededProperties, Logger logger) {
+  for (var property in seededProperties) {
+    try {
+      // This will throw an exception if we cannot decode the json
+      Property.fromJson(jsonEncode(property));
+    } catch (e) {
+      logger.err('''Could not parse property: ${property.toString()}
+Please check the variable names of your properties. It should be along the lines of:
+{ "name": "firstName", "type": "String" }
+''');
+      exit(0);
+    }
+  }
+}
+
+/// Adds properties to the model until the user escapes by entering `e`.
+void _addProperties(Logger logger, List<Map<String, dynamic>> properties) {
+  logger.info(lightYellow.wrap('enter `e` to exit adding properties'));
+  logger.info(lightYellow
+      .wrap('Format: dataType propertyName e.g, String myProperty:'));
 
   while (true) {
     final property = logger.prompt(':').replaceAll(RegExp('\\s+'), ' ').trim();
@@ -85,25 +122,98 @@ void run(HookContext context) {
     final splitProperty = property.split(' ');
     final propertyType = splitProperty[0];
     final propertyName = splitProperty[1];
-    final hasSpecial = propertyType.toLowerCase().contains('<') ||
-        propertyType.toLowerCase().contains('>');
-    final listProperties = _getCustomListProperties(hasSpecial, propertyType);
-    final isCustomDataType = !dataTypes.contains(propertyType) && !hasSpecial;
-    properties.add({
-      'name': propertyName,
-      'type': propertyType,
-      'hasSpecial': hasSpecial,
-      'isCustomDataType': isCustomDataType,
-      ...listProperties,
-    });
+    _addProperty(properties, Property(name: propertyName, type: propertyType));
   }
-  context.vars = {
-    ...vars,
-    'properties': properties,
-    'hasProperties': properties.isNotEmpty,
-  };
 }
 
+/// Adds a property to the [properties] list.
+void _addProperty(
+  List<Map<String, dynamic>> properties,
+  Property property,
+) {
+  final hasSpecial = property.type.toLowerCase().contains('<') ||
+      property.type.toLowerCase().contains('>');
+  final listProperties = _getCustomListProperties(hasSpecial, property.type);
+  final isCustomDataType = !dataTypes.contains(property.type) && !hasSpecial;
+  properties.add({
+    'name': property.name,
+    'type': property.type,
+    'hasSpecial': hasSpecial,
+    'isCustomDataType': isCustomDataType,
+    ...listProperties,
+  });
+}
+
+/// Checks to see if the current output directory is in the
+/// lib folder.
+/// Adds the fullPath to the current working directory
+Future<void> _validateDirectory(HookContext context) async {
+  final logger = context.logger;
+  final directory = Directory.current.path;
+
+  try {
+    List<String> folders;
+
+    if (Platform.isWindows) {
+      folders = directory.split(r'\').toList();
+    } else {
+      folders = directory.split('/').toList();
+    }
+    final libIndex = folders.indexWhere((folder) => folder == 'lib');
+    final modelPath = folders.sublist(libIndex + 1, folders.length).join('/');
+    final pubSpecFile =
+        File('${folders.sublist(0, libIndex).join('/')}/pubspec.yaml');
+    final content = await pubSpecFile.readAsString();
+    final yamlMap = loadYaml(content);
+    final packageName = yamlMap['name'];
+    context.vars = {
+      ...context.vars,
+      'fullPath': ('$packageName/$modelPath/').replaceAll('//', '/'),
+    };
+  } on RangeError catch (_) {
+    logger.alert(
+      red.wrap(
+        'Could not find lib folder in $directory',
+      ),
+    );
+    logger.alert(
+      red.wrap(
+        'Re-run this brick inside your lib folder',
+      ),
+    );
+    throw Exception();
+  } on FileSystemException catch (_) {
+    logger.alert(
+      red.wrap(
+        'Could not find pubspec.yaml folder in ${directory.replaceAll('\\lib', '')}',
+      ),
+    );
+
+    throw Exception();
+  } on PubspecNameException catch (_) {
+    logger.alert(
+      red.wrap(
+        'Could not read package name in pubspec.yaml',
+      ),
+    );
+    logger.alert(
+      red.wrap(
+        'Does your pubspec have a name ?',
+      ),
+    );
+    throw Exception();
+  } on Exception catch (e) {
+    throw e;
+  }
+}
+
+/// Checks to see if the property type is special.
+///
+/// This check is required due to the mustache syntax:
+/// All variables are HTML escaped by default. If you want
+/// to return unescaped HTML, use the triple mustache: {{{name}}}.
+///
+/// returns a [Map<String, dynamic>] containing the properties variables
 Map<String, dynamic> _getCustomListProperties(
   bool hasSpecial,
   String propertyType,
@@ -126,3 +236,25 @@ Map<String, dynamic> _getCustomListProperties(
     'customListType': listType,
   };
 }
+
+class Property {
+  const Property({
+    required this.name,
+    required this.type,
+  });
+
+  final String name;
+  final String type;
+
+  factory Property.fromMap(Map<String, dynamic> map) {
+    return Property(
+      name: map['name'],
+      type: map['type'],
+    );
+  }
+
+  factory Property.fromJson(String source) =>
+      Property.fromMap(json.decode(source));
+}
+
+class PubspecNameException implements Exception {}

--- a/bricks/model/hooks/pubspec.yaml
+++ b/bricks/model/hooks/pubspec.yaml
@@ -5,3 +5,4 @@ environment:
 
 dependencies:
   mason: ^0.1.0-dev
+  yaml: ^3.1.1

--- a/bricks/model/model_config_template.json
+++ b/bricks/model/model_config_template.json
@@ -1,0 +1,16 @@
+{
+  "model_name": "user",
+  "additionals": ["copyWith", "json", "equatable"],
+  "style": "json_serializable",
+  "relations": [{ "name": "user" }],
+  "properties": [
+    { "name": "firstName", "type": "String" },
+    { "name": "lastName", "type": "String" },
+    { "name": "age", "type": "int" },
+    { "name": "isHappy", "type": "bool" },
+    { "name": "favouriteNumber", "type": "int" },
+    { "name": "nicknames", "type": "List<String>" },
+    { "name": "countriesVisited", "type": "List<String>" },
+    { "name": "friends", "type": "List<User>" }
+  ]
+}


### PR DESCRIPTION
## Brick

<!--- Put an `x` in all the boxes that apply: -->

- [x] model
- [ ] feature_brick
- [ ] app_ui
- [ ] service
- [ ] service_package

## Status

**READY**

## Breaking Changes

NO

## Description

This PR adds the following changes:

- feat: Allow for seeding/configs for a whole model including the properties

- feat: Relate models to generate their imports (Currently config only)

- chore: Update documentation with information about configs and how it differs from regular command line generation

- bug: Update fromJson to be a factory method

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
