### PR TITLE
feat: Added toString() override

### DIFF
--- a/bricks/model/README.md
+++ b/bricks/model/README.md
@@ -24,7 +24,7 @@ Then add your properties! (Optional)
 | Variable      | Description                                                | Default                                   | Type     |
 | ------------- | ---------------------------------------------------------- | ----------------------------------------- | -------- |
 | `model_name`  | The name of the model                                      | model                                     | `string` |
-| `additionals` | The additionals methods/extensions you can have on a model | [copyWith, json, equatable]               | `array`  |
+| `additionals` | The additionals methods/extensions you can have on a model | [copyWith, json, equatable, toString]     | `array`  |
 | `style`       | The style of model                                         | basic (basic, json_serializable, freezed) | `enum`   |
 
 ### Config
@@ -36,7 +36,7 @@ Then add your properties! (Optional)
 ```json
 {
   "model_name": "super user",
-  "additionals": ["copyWith", "json", "equatable"],
+  "additionals": ["copyWith", "json", "equatable", "toString"],
   "style": "json_serializable", // Could be basic, json_serializable, or freezed
   "relations": [{ "name": "user" }], // Use this when your model depends on other models
   "properties": [
@@ -65,7 +65,7 @@ Then add your properties! (Optional)
 ## Outputs 📦
 
 ```
---model_name user --additionals "[copyWith, json, equatable]" --style json_serializable
+--model_name user --additionals "[copyWith, json, equatable, toString]" --style json_serializable
 ├── user.dart
 ├── user.g.dart
 └── ...
@@ -123,6 +123,10 @@ class User extends Equatable {
 
   /// Creates a Json map from a User
   Map<String, dynamic> toJson() => _$UserToJson(this);
+
+  /// Creates a toString() override for User
+  @override
+  String toString() => 'User(name: $name, familyMembers: $familyMembers, family: $family)';
 }
 
 //user.g.dart

--- a/bricks/model/__brick__/{{~ basic_model }}
+++ b/bricks/model/__brick__/{{~ basic_model }}
@@ -19,4 +19,6 @@ class {{model_name.pascalCase()}}{{#use_equatable}} extends Equatable{{/use_equa
   {{> equatable_props }}{{/use_equatable}}
 {{#use_json}}
   {{> basic_to_json }}{{/use_json}}
+{{#use_tostring}}
+  {{> to_string }}{{/use_tostring}}
 }

--- a/bricks/model/__brick__/{{~ serializable_model }}
+++ b/bricks/model/__brick__/{{~ serializable_model }}
@@ -24,4 +24,6 @@ class {{model_name.pascalCase()}}{{#use_equatable}} extends Equatable{{/use_equa
   {{> equatable_props }}{{/use_equatable}}
 {{#use_json}}
   {{> serializable_to_json }}{{/use_json}}
+{{#use_tostring}}
+  {{> to_string }}{{/use_tostring}}
 }

--- a/bricks/model/__brick__/{{~ to_string }}
+++ b/bricks/model/__brick__/{{~ to_string }}
@@ -1,0 +1,3 @@
+/// Creates a toString() override for {{model_name.pascalCase()}}
+@override
+String toString() => '{{model_name.pascalCase()}}({{#properties}}{{name}}: ${{name}}{{^isLastProperty}}, {{/isLastProperty}}{{/properties}})';

--- a/bricks/model/brick.yaml
+++ b/bricks/model/brick.yaml
@@ -11,13 +11,14 @@ vars:
     prompt: What is the models name?
   additionals:
     type: array
-    defaults: [copyWith, json, equatable]
+    defaults: [copyWith, json, equatable, toString]
     description: The additional methods/extensions you can have on a model
     prompt: What additional methods/extensions should the model have?
     values:
       - copyWith
       - json
       - equatable
+      - toString
   style:
     type: enum
     default: basic

--- a/bricks/model/hooks/pre_gen.dart
+++ b/bricks/model/hooks/pre_gen.dart
@@ -29,6 +29,7 @@ Future<void> run(HookContext context) async {
     'use_copywith': additionals.contains('copyWith'),
     'use_json': additionals.contains('json'),
     'use_equatable': additionals.contains('equatable'),
+    'use_tostring': additionals.contains('toString'),
     'use_none': model_style == 'basic',
     'use_serializable': model_style == 'json_serializable',
     'use_freezed': model_style == 'freezed',
@@ -140,14 +141,17 @@ void _addProperty(
   final listProperties = _getCustomListProperties(hasSpecial, property.type);
   final isCustomDataType =
       !dataTypes.contains(property.type.cleaned) && !hasSpecial;
-  properties.add({
-    'name': property.name,
-    'type': property.type,
-    'isNullable': property.isNullable,
-    'hasSpecial': hasSpecial,
-    'isCustomDataType': isCustomDataType,
-    ...listProperties,
-  });
+  properties
+    ..forEach((e) => e['isLastProperty'] = false)
+    ..add({
+      'name': property.name,
+      'type': property.type,
+      'isNullable': property.isNullable,
+      'hasSpecial': hasSpecial,
+      'isCustomDataType': isCustomDataType,
+      'isLastProperty': true,
+      ...listProperties,
+    });
 }
 
 /// Checks to see if the current output directory is in the


### PR DESCRIPTION
<!--
  Thanks for contributing to brick!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Brick

<!--- Put an `x` in all the boxes that apply: -->

- [x] model
- [ ] models_bundle
- [ ] feature_brick
- [ ] feature_brick_tests
- [ ] app_ui
- [ ] service
- [ ] service_package

## Status

**READY**

## Breaking Changes

NO

## Description

This PR aims to add a `toString()` override for the generated models. This ensures that whenever the model is printed in the console, it will return the actual data of the model:
```
'User(name: $name, familyMembers: $familyMembers, family: $family)'
```
instead of:
```
Instance of 'User'
```

The changes are required only when the style is basic and json_serializable. Freezed already has its own implementation of the `toString()` override so it is not required when the developer uses this style. Therefore, only the `{{~ basic_model }}` and `{{~ serializable_model }}` have the new toString method added (`{{~ to_string }}`). 

There have been additional changes inside the `pre_gen.dart` file to identify when the parameters end. This is needed to ensure that the resulting `toString()` text does not have a trailing `, ` and is nicely formatted.
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
