### PR TITLE
feat: Add hive as an option to the model brick

### DIFF
--- a/bricks/model/__brick__/{{model_name.snakeCase()}}.dart
+++ b/bricks/model/__brick__/{{model_name.snakeCase()}}.dart
@@ -1,1 +1,1 @@
-{{#use_none}}{{> basic_model }}{{/use_none}}{{#use_serializable}}{{> serializable_model }}{{/use_serializable}}{{#use_freezed}}{{> freezed_model }}{{/use_freezed}}
+{{#use_none}}{{> basic_model }}{{/use_none}}{{#use_serializable}}{{> serializable_model }}{{/use_serializable}}{{#use_freezed}}{{> freezed_model }}{{/use_freezed}}{{#use_hive}}{{> hive_model }}{{/use_hive}}

--- a/bricks/model/__brick__/{{~ hive_model }}
+++ b/bricks/model/__brick__/{{~ hive_model }}
@@ -1,0 +1,21 @@
+import 'package:hive/hive.dart';
+{{> relations }}
+part '{{model_name.snakeCase()}}.g.dart';
+
+/// {@template {{{model_name.snakeCase()}}}}
+/// {{model_name.pascalCase()}} description
+/// {@endtemplate}
+@HiveType(typeId: 0) // TODO: Set your typeId
+class {{model_name.pascalCase()}} extends HiveObject {
+  /// {@macro {{{model_name.snakeCase()}}}}
+  {{model_name.pascalCase()}}({{#hasProperties}}{ {{#properties}}
+    {{^isNullable}}required {{/isNullable}}this.{{name.camelCase()}},{{/properties}}
+  }{{/hasProperties}});
+{{#properties}}
+  /// A description for {{name.camelCase()}}
+  @HiveField({{index}})
+  final {{#hasSpecial}}{{{type}}}{{/hasSpecial}}{{^hasSpecial}}{{type}}{{/hasSpecial}} {{name.camelCase()}};
+{{/properties}}{{#use_copywith}}
+  {{> copy_with }}{{/use_copywith}}{{#use_tostring}}
+  {{> to_string }}{{/use_tostring}}
+}

--- a/bricks/model/brick.yaml
+++ b/bricks/model/brick.yaml
@@ -28,6 +28,7 @@ vars:
       - basic
       - json_serializable
       - freezed
+      - hive
   jsonFile:
     default: ""
     type: string

--- a/bricks/model/hooks/model_service.dart
+++ b/bricks/model/hooks/model_service.dart
@@ -88,9 +88,16 @@ Please check the variable names of your properties. It should be along the lines
     final listProperties = getCustomListProperties(hasSpecial, property.type);
     final isCustomDataType =
         !DataTypes.values.contains(property.type.cleaned) && !hasSpecial;
+    var index = 0;
+
     properties
-      ..forEach((e) => e['isLastProperty'] = false)
+      ..forEach((e) {
+        e['isLastProperty'] = false;
+        e['index'] = index;
+        index = index + 1;
+      })
       ..add({
+        'index': index,
         'name': property.name,
         'type': property.type,
         'hasSpecial': hasSpecial,

--- a/bricks/model/hooks/pre_gen.dart
+++ b/bricks/model/hooks/pre_gen.dart
@@ -26,6 +26,7 @@ Future<void> run(HookContext context) async {
     'use_none': modelStyle == 'basic',
     'use_serializable': modelStyle == 'json_serializable',
     'use_freezed': modelStyle == 'freezed',
+    'use_hive': modelStyle == 'hive',
     'jsonIndex': ((context.vars['jsonIndex'] as int?) ?? 0),
   };
 


### PR DESCRIPTION
This PR is related to https://github.com/LukeMoody01/mason_bricks/issues/36

## Brick

<!--- Put an `x` in all the boxes that apply: -->

- [x] model
- [ ] models_bundle
- [ ] feature_brick
- [ ] feature_brick_tests
- [ ] app_ui
- [ ] service
- [ ] service_package

## Status

**READY**

## Breaking Changes

NO

## Description

- Hive option added in style model enum.
- Hive model created.
- Index workaround: Each property in a Hive model needs an "id" in the annotation `@HiveField({id})`. Since the index of the properties loop is not accessible through mason's syntax, I've implemented a workaround to hardcode a property "index" for each property model. You can refer the following issue: https://github.com/felangel/mason/issues/419

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
